### PR TITLE
Add better typings for DocumentReference's get and doc methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -652,9 +652,9 @@ type DocumentReference<docAndSub extends DocumentAndSubCollectionData> = {
    * @return A Promise resolved with a DocumentSnapshot containing the
    * current document contents.
    */
-  readonly get: (
+  readonly get: <T extends docAndSub["key"]>(
     options?: firestore.GetOptions
-  ) => Promise<DocumentSnapshot<docAndSub["key"], docAndSub["value"]>>;
+  ) => Promise<DocumentSnapshot<T, Extract<docAndSub, { key: T }>["value"]>>;
 
   /**
    * Attaches a listener for DocumentSnapshot events. You may either pass
@@ -1274,9 +1274,9 @@ type CollectionReference<
    * @param documentPath A slash-separated path to a document.
    * @return The `DocumentReference` instance.
    */
-  readonly doc: (
-    documentPath?: docAndSub["key"]
-  ) => DocumentReference<docAndSub>;
+  readonly doc: <T extends docAndSub["key"]>(
+    documentPath?: T
+  ) => DocumentReference<Extract<docAndSub, { key: T }>>;
 
   /**
    * Add a new document to this collection with the specified data, assigning

--- a/sample.ts
+++ b/sample.ts
@@ -4,6 +4,23 @@ import * as firestore from "@firebase/firestore-types";
 const firestoreInstance = (({} as firestore.FirebaseFirestore) as unknown) as f.Firestore<{
   user: { key: UserId; value: User; subCollections: {} };
   music: { key: MusicId; value: Music; subCollections: {} };
+  withSubcollection: {
+    key: string;
+    value: never;
+    subCollections: {
+      data:
+        | {
+            key: "SubcollectionDoc1";
+            value: SubcollectionDoc1;
+            subCollections: {};
+          }
+        | {
+            key: "SubcollectionDoc2";
+            value: SubcollectionDoc2;
+            subCollections: {};
+          };
+    };
+  };
 }>;
 
 type UserId = string & { _userId: never };
@@ -26,6 +43,14 @@ type Music = {
   artist: UserId;
 };
 
+type SubcollectionDoc1 = {
+  field1: string;
+};
+
+type SubcollectionDoc2 = {
+  field2: string;
+};
+
 (async () => {
   const userQuerySnapshotArray = await firestoreInstance
     .collection("user")
@@ -42,4 +67,11 @@ type Music = {
       firestoreInstance.collection("user").doc(likedMusicId); // error !!!
     }
   }
+
+  const doc = await firestoreInstance
+    .collection("withSubcollection") // autocomplete
+    .doc("id" as string)
+    .collection("data") // autocomplete
+    .doc("SubcollectionDoc1") // autocomplete
+    .get(); // returns DocumentSnapshot of SubcollectionDoc1
 })();


### PR DESCRIPTION
Hi, while using your library I was forced to cast values returned from `DocumentReference`'s `get` method.
I added an example of such situation to `sample.ts`. 

Without my changes, the type of `doc` would be inferred as `f.DocumentSnapshot<"SubcollectionDoc1" | "SubcollectionDoc2", SubcollectionDoc1 | SubcollectionDoc2>` which would force me to cast it to my desired type. 

By applying my changes you get proper type: `f.DocumentSnapshot<"SubcollectionDoc1", SubcollectionDoc1>`.